### PR TITLE
Update plans tab functionality and theme

### DIFF
--- a/src/components/PaymentForm.tsx
+++ b/src/components/PaymentForm.tsx
@@ -193,7 +193,7 @@ export const PaymentForm = () => {
   };
 
   return (
-    <Card className="max-w-2xl mx-auto">
+    <Card className="max-w-2xl mx-auto cyber-card">
       <CardHeader>
         <CardTitle className="flex items-center">
           <CreditCard className="h-5 w-5 mr-2" />
@@ -208,7 +208,7 @@ export const PaymentForm = () => {
             const plan = plans.find(p => p.id === value);
             setSelectedPlan(plan || null);
           }}>
-            <SelectTrigger>
+            <SelectTrigger className="border-cyber-blue-200 focus:border-cyber-blue-500">
               <SelectValue placeholder="Choose your internet plan" />
             </SelectTrigger>
             <SelectContent>
@@ -226,16 +226,16 @@ export const PaymentForm = () => {
 
         {/* Selected Plan Details */}
         {selectedPlan && (
-          <Card className="bg-blue-50">
+          <Card className="bg-cyber-blue-50/10 border-cyber-blue-200">
             <CardContent className="pt-4">
-              <h3 className="font-semibold text-lg">{selectedPlan.name}</h3>
+              <h3 className="font-semibold text-lg text-foreground">{selectedPlan.name}</h3>
               <div className="grid grid-cols-2 gap-4 mt-2 text-sm">
-                <div>Speed: {selectedPlan.speed_limit_mbps} Mbps</div>
-                <div>Validity: {selectedPlan.validity_days} days</div>
-                <div>Price: KES {selectedPlan.price_kes.toLocaleString()}</div>
+                <div className="text-muted-foreground">Speed: {selectedPlan.speed_limit_mbps} Mbps</div>
+                <div className="text-muted-foreground">Validity: {selectedPlan.validity_days} days</div>
+                <div className="text-muted-foreground">Price: KES {selectedPlan.price_kes.toLocaleString()}</div>
               </div>
               {selectedPlan.description && (
-                <p className="text-sm text-gray-600 mt-2">{selectedPlan.description}</p>
+                <p className="text-sm text-muted-foreground mt-2">{selectedPlan.description}</p>
               )}
             </CardContent>
           </Card>
@@ -251,31 +251,32 @@ export const PaymentForm = () => {
             value={phoneNumber}
             onChange={(e) => setPhoneNumber(e.target.value)}
             disabled={loading}
+            className="border-cyber-blue-200 focus:border-cyber-blue-500"
           />
-          <p className="text-sm text-gray-600">
+          <p className="text-sm text-muted-foreground">
             Enter the phone number linked to your M-Pesa account
           </p>
         </div>
 
         {/* Payment Status */}
         {paymentStatus === 'processing' && (
-          <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+          <div className="bg-cyber-orange-50 border border-cyber-orange-200 rounded-lg p-4">
             <div className="flex items-center">
               <Loader2 className="h-4 w-4 animate-spin mr-2" />
-              <span>Payment processing... Check your phone for M-Pesa prompt</span>
+              <span className="text-cyber-orange-800">Payment processing... Check your phone for M-Pesa prompt</span>
             </div>
           </div>
         )}
 
         {paymentStatus === 'success' && (
-          <div className="bg-green-50 border border-green-200 rounded-lg p-4">
-            <span className="text-green-800">Payment successful! Your subscription is now active.</span>
+          <div className="bg-cyber-green-50 border border-cyber-green-200 rounded-lg p-4">
+            <span className="text-cyber-green-800">Payment successful! Your subscription is now active.</span>
           </div>
         )}
 
         {paymentStatus === 'failed' && (
-          <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-            <span className="text-red-800">Payment failed. Please try again.</span>
+          <div className="bg-cyber-red-50 border border-cyber-red-200 rounded-lg p-4">
+            <span className="text-cyber-red-800">Payment failed. Please try again.</span>
           </div>
         )}
 
@@ -283,7 +284,7 @@ export const PaymentForm = () => {
         <Button 
           onClick={handlePayment} 
           disabled={!selectedPlan || !phoneNumber || loading}
-          className="w-full"
+          className="w-full btn-primary"
           size="lg"
         >
           {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}

--- a/src/components/PlanUpgradeEnhanced.tsx
+++ b/src/components/PlanUpgradeEnhanced.tsx
@@ -6,6 +6,10 @@ import { PlanCard } from '@/components/ui/plan-card';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Loader2, CreditCard, Smartphone } from 'lucide-react';
 
 interface Plan {
   id: string;
@@ -30,6 +34,10 @@ const PlanUpgradeEnhanced = () => {
   const [currentSubscription, setCurrentSubscription] = useState<CurrentSubscription | null>(null);
   const [loading, setLoading] = useState(true);
   const [processingPayment, setProcessingPayment] = useState<string | null>(null);
+  const [showPaymentDialog, setShowPaymentDialog] = useState(false);
+  const [selectedPlan, setSelectedPlan] = useState<Plan | null>(null);
+  const [phoneNumber, setPhoneNumber] = useState('');
+  const [paymentStatus, setPaymentStatus] = useState<'idle' | 'processing' | 'success' | 'failed'>('idle');
   const { toast } = useToast();
 
   // Test Supabase connection on mount
@@ -172,42 +180,150 @@ const PlanUpgradeEnhanced = () => {
     fetchData();
   }, []);
 
-  const handlePaymentSelection = async (planId: string, paymentMethod: string) => {
+  const validatePhoneNumber = (phone: string): boolean => {
+    // Kenyan phone number validation
+    const phoneRegex = /^(\+254|254|0)(7|1)[0-9]{8}$/;
+    return phoneRegex.test(phone);
+  };
+
+  const formatPhoneNumber = (phone: string): string => {
+    // Convert to 254XXXXXXXXX format
+    if (phone.startsWith('+254')) {
+      return phone.slice(1);
+    } else if (phone.startsWith('0')) {
+      return `254${phone.slice(1)}`;
+    } else if (phone.startsWith('254')) {
+      return phone;
+    }
+    return phone;
+  };
+
+  const handlePlanSelection = (plan: Plan) => {
+    setSelectedPlan(plan);
+    setShowPaymentDialog(true);
+    setPaymentStatus('idle');
+    setPhoneNumber('');
+  };
+
+  const handlePayment = async () => {
+    if (!selectedPlan) {
+      toast({
+        title: "Error",
+        description: "Please select a plan",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    if (!validatePhoneNumber(phoneNumber)) {
+      toast({
+        title: "Error",
+        description: "Please enter a valid Kenyan phone number",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setProcessingPayment(selectedPlan.id);
+    setPaymentStatus('processing');
+
     try {
-      setProcessingPayment(planId);
-
-      // Here you would integrate with actual payment processors
-      // For now, we'll simulate the process
+      const { data: { user } } = await supabase.auth.getUser();
       
-      toast({
-        title: "Payment Processing",
-        description: `Redirecting to ${paymentMethod} payment gateway...`,
+      if (!user) {
+        throw new Error('User not authenticated');
+      }
+
+      const formattedPhone = formatPhoneNumber(phoneNumber);
+      
+      const { data, error } = await supabase.functions.invoke('mpesa-stk-push', {
+        body: {
+          amount: selectedPlan.price_kes,
+          phone: formattedPhone,
+          account_reference: `PLAN_${selectedPlan.id}`,
+          user_id: user.id,
+          email: user.email
+        }
       });
 
-      // Simulate payment processing delay
-      await new Promise(resolve => setTimeout(resolve, 2000));
+      if (error) throw error;
 
-      // In a real implementation, you would:
-      // 1. Create a payment intent with the selected payment method
-      // 2. Redirect to payment gateway
-      // 3. Handle payment callback
-      // 4. Update subscription in database
-
+      if (data.success) {
+        toast({
+          title: "Payment Initiated",
+          description: "Please check your phone for the M-Pesa prompt",
+        });
+        
+        // Poll for payment status
+        pollPaymentStatus(data.payment_id);
+      } else {
+        throw new Error(data.error || 'Payment initiation failed');
+      }
+    } catch (error: any) {
+      console.error('Payment error:', error);
+      setPaymentStatus('failed');
       toast({
-        title: "Payment Processing",
-        description: "Please complete the payment in the new window",
-      });
-
-    } catch (error) {
-      console.error('Error processing payment:', error);
-      toast({
-        title: "Payment Error",
-        description: "Failed to process payment. Please try again.",
+        title: "Payment Failed",
+        description: error.message || "Failed to initiate payment",
         variant: "destructive",
       });
     } finally {
       setProcessingPayment(null);
     }
+  };
+
+  const pollPaymentStatus = async (paymentId: string) => {
+    const maxAttempts = 30; // 5 minutes of polling
+    let attempts = 0;
+
+    const poll = async () => {
+      try {
+        const { data, error } = await supabase
+          .from('payments')
+          .select('status')
+          .eq('id', paymentId)
+          .single();
+
+        if (error) throw error;
+
+        if (data.status === 'success') {
+          setPaymentStatus('success');
+          toast({
+            title: "Payment Successful",
+            description: "Your subscription has been activated!",
+          });
+          setShowPaymentDialog(false);
+          // Refresh the data
+          await fetchData();
+          return;
+        } else if (data.status === 'failed') {
+          setPaymentStatus('failed');
+          toast({
+            title: "Payment Failed",
+            description: "Payment was not completed. Please try again.",
+            variant: "destructive",
+          });
+          return;
+        }
+
+        attempts++;
+        if (attempts < maxAttempts) {
+          setTimeout(poll, 10000); // Poll every 10 seconds
+        } else {
+          setPaymentStatus('idle');
+          toast({
+            title: "Payment Status Unknown",
+            description: "Please check your payment history or contact support",
+            variant: "destructive",
+          });
+        }
+      } catch (error) {
+        console.error('Polling error:', error);
+        setPaymentStatus('idle');
+      }
+    };
+
+    poll();
   };
 
   if (loading) {
@@ -222,29 +338,29 @@ const PlanUpgradeEnhanced = () => {
     <div className="space-y-8">
       {/* Header */}
       <div className="text-center space-y-4">
-        <h2 className="text-3xl font-heading font-bold text-gray-900">
+        <h2 className="text-3xl font-heading font-bold text-foreground">
           Choose Your Internet Plan
         </h2>
-        <p className="text-lg text-gray-600 max-w-2xl mx-auto">
+        <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
           Select the perfect plan for your needs. Upgrade or downgrade anytime with no hidden fees.
         </p>
       </div>
 
       {/* Current Plan Info */}
       {currentSubscription && (
-        <Card className="professional-card border-isp-blue-200 bg-isp-blue-50">
+        <Card className="professional-card border-cyber-blue-200 bg-cyber-blue-50/10">
           <CardHeader>
             <div className="flex items-center justify-between">
               <div>
-                <CardTitle className="text-lg text-isp-blue-700">
+                <CardTitle className="text-lg text-cyber-blue-700 dark:text-cyber-blue-300">
                   Your Current Plan
                 </CardTitle>
-                <CardDescription className="text-isp-blue-600">
+                <CardDescription className="text-cyber-blue-600 dark:text-cyber-blue-400">
                   {currentSubscription.plans.name} - Active until{' '}
                   {new Date(currentSubscription.end_date).toLocaleDateString()}
                 </CardDescription>
               </div>
-              <Badge className="bg-isp-teal-100 text-isp-teal-800">
+              <Badge className="bg-cyber-green-100 text-cyber-green-800 dark:bg-cyber-green-900 dark:text-cyber-green-200">
                 Active
               </Badge>
             </div>
@@ -255,30 +371,169 @@ const PlanUpgradeEnhanced = () => {
       {/* Plans Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
         {plans.map((plan) => (
-          <PlanCard
-            key={plan.id}
-            plan={plan}
-            onSelectPayment={handlePaymentSelection}
-            loading={processingPayment === plan.id}
-          />
+          <Card key={plan.id} className="professional-card hover:shadow-cyber-glow transition-all duration-300">
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <CardTitle className="text-xl font-bold text-foreground">{plan.name}</CardTitle>
+                {plan.popular && (
+                  <Badge className="bg-cyber-purple-100 text-cyber-purple-800 dark:bg-cyber-purple-900 dark:text-cyber-purple-200">
+                    Popular
+                  </Badge>
+                )}
+              </div>
+              <CardDescription className="text-muted-foreground">
+                {plan.description}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="text-center">
+                <div className="text-3xl font-bold text-cyber-blue-600 dark:text-cyber-blue-400">
+                  KES {plan.price_kes.toLocaleString()}
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  for {plan.validity_days} days
+                </div>
+              </div>
+              
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-muted-foreground">Speed</span>
+                  <span className="font-semibold text-foreground">{plan.speed_limit_mbps} Mbps</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-sm text-muted-foreground">Validity</span>
+                  <span className="font-semibold text-foreground">{plan.validity_days} days</span>
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <h4 className="font-semibold text-sm text-foreground">Features:</h4>
+                <ul className="space-y-1">
+                  {plan.features?.slice(0, 3).map((feature, index) => (
+                    <li key={index} className="text-sm text-muted-foreground flex items-center">
+                      <span className="w-1.5 h-1.5 bg-cyber-blue-500 rounded-full mr-2"></span>
+                      {feature}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <Button 
+                onClick={() => handlePlanSelection(plan)}
+                className="w-full bg-cyber-blue-600 hover:bg-cyber-blue-700 text-white"
+                disabled={plan.current}
+              >
+                {plan.current ? 'Current Plan' : 'Select Plan'}
+              </Button>
+            </CardContent>
+          </Card>
         ))}
       </div>
 
+      {/* Payment Dialog */}
+      <Dialog open={showPaymentDialog} onOpenChange={setShowPaymentDialog}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="flex items-center">
+              <CreditCard className="h-5 w-5 mr-2" />
+              Complete Payment
+            </DialogTitle>
+            <DialogDescription>
+              Enter your M-Pesa phone number to proceed with the payment for {selectedPlan?.name}
+            </DialogDescription>
+          </DialogHeader>
+          
+          <div className="space-y-4">
+            {selectedPlan && (
+              <Card className="bg-cyber-blue-50/10 border-cyber-blue-200">
+                <CardContent className="pt-4">
+                  <h3 className="font-semibold text-lg text-foreground">{selectedPlan.name}</h3>
+                  <div className="grid grid-cols-2 gap-4 mt-2 text-sm">
+                    <div className="text-muted-foreground">Speed: {selectedPlan.speed_limit_mbps} Mbps</div>
+                    <div className="text-muted-foreground">Validity: {selectedPlan.validity_days} days</div>
+                    <div className="text-muted-foreground">Price: KES {selectedPlan.price_kes.toLocaleString()}</div>
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+
+            <div className="space-y-2">
+              <Label htmlFor="phone" className="flex items-center">
+                <Smartphone className="h-4 w-4 mr-2" />
+                M-Pesa Phone Number
+              </Label>
+              <Input
+                id="phone"
+                type="tel"
+                placeholder="+254700000000 or 0700000000"
+                value={phoneNumber}
+                onChange={(e) => setPhoneNumber(e.target.value)}
+                disabled={paymentStatus === 'processing'}
+                className="border-cyber-blue-200 focus:border-cyber-blue-500"
+              />
+              <p className="text-xs text-muted-foreground">
+                Enter the phone number linked to your M-Pesa account
+              </p>
+            </div>
+
+            {/* Payment Status */}
+            {paymentStatus === 'processing' && (
+              <div className="bg-cyber-orange-50 border border-cyber-orange-200 rounded-lg p-4">
+                <div className="flex items-center">
+                  <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                  <span className="text-cyber-orange-800">Payment processing... Check your phone for M-Pesa prompt</span>
+                </div>
+              </div>
+            )}
+
+            {paymentStatus === 'success' && (
+              <div className="bg-cyber-green-50 border border-cyber-green-200 rounded-lg p-4">
+                <span className="text-cyber-green-800">Payment successful! Your subscription is now active.</span>
+              </div>
+            )}
+
+            {paymentStatus === 'failed' && (
+              <div className="bg-cyber-red-50 border border-cyber-red-200 rounded-lg p-4">
+                <span className="text-cyber-red-800">Payment failed. Please try again.</span>
+              </div>
+            )}
+
+            <div className="flex space-x-2">
+              <Button 
+                onClick={handlePayment} 
+                disabled={!phoneNumber || paymentStatus === 'processing'}
+                className="flex-1 bg-cyber-blue-600 hover:bg-cyber-blue-700 text-white"
+              >
+                {paymentStatus === 'processing' && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Pay KES {selectedPlan?.price_kes.toLocaleString() || '0'}
+              </Button>
+              <Button 
+                variant="outline" 
+                onClick={() => setShowPaymentDialog(false)}
+                disabled={paymentStatus === 'processing'}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
       {/* Additional Information */}
-      <div className="bg-isp-gray-50 rounded-xl p-6 space-y-4">
-        <h3 className="text-lg font-semibold text-gray-900">
+      <div className="bg-cyber-gray-50/10 rounded-xl p-6 space-y-4 border border-cyber-gray-200">
+        <h3 className="text-lg font-semibold text-foreground">
           Plan Change Policy
         </h3>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-gray-600">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-muted-foreground">
           <div>
-            <h4 className="font-medium text-gray-900 mb-2">Upgrades</h4>
+            <h4 className="font-medium text-foreground mb-2">Upgrades</h4>
             <p>
               Plan upgrades take effect immediately. You'll be charged the prorated 
               difference for the remaining period.
             </p>
           </div>
           <div>
-            <h4 className="font-medium text-gray-900 mb-2">Downgrades</h4>
+            <h4 className="font-medium text-foreground mb-2">Downgrades</h4>
             <p>
               Plan downgrades take effect at the end of your current billing period. 
               No partial refunds are provided.

--- a/src/components/UserDashboard.tsx
+++ b/src/components/UserDashboard.tsx
@@ -201,21 +201,21 @@ const UserDashboard = React.memo(() => {
       <UserStats subscription={subscription} daysRemaining={daysRemaining} />
 
       {/* Main Content Tabs */}
-      <Tabs defaultValue="overview" className="space-y-6">
+      <Tabs defaultValue="plans" className="space-y-6">
         <TabsList className="grid w-full grid-cols-5 bg-white shadow-soft border">
-          <TabsTrigger value="overview" className="data-[state=active]:bg-isp-blue-600 data-[state=active]:text-white">
+          <TabsTrigger value="overview" className="data-[state=active]:bg-cyber-blue-600 data-[state=active]:text-white">
             Overview
           </TabsTrigger>
-          <TabsTrigger value="usage" className="data-[state=active]:bg-isp-blue-600 data-[state=active]:text-white">
+          <TabsTrigger value="usage" className="data-[state=active]:bg-cyber-blue-600 data-[state=active]:text-white">
             Usage
           </TabsTrigger>
-          <TabsTrigger value="plans" className="data-[state=active]:bg-isp-blue-600 data-[state=active]:text-white">
+          <TabsTrigger value="plans" className="data-[state=active]:bg-cyber-blue-600 data-[state=active]:text-white">
             Plans
           </TabsTrigger>
-          <TabsTrigger value="payments" className="data-[state=active]:bg-isp-blue-600 data-[state=active]:text-white">
+          <TabsTrigger value="payments" className="data-[state=active]:bg-cyber-blue-600 data-[state=active]:text-white">
             Payments
           </TabsTrigger>
-          <TabsTrigger value="history" className="data-[state=active]:bg-isp-blue-600 data-[state=active]:text-white">
+          <TabsTrigger value="history" className="data-[state=active]:bg-cyber-blue-600 data-[state=active]:text-white">
             History
           </TabsTrigger>
         </TabsList>
@@ -235,14 +235,8 @@ const UserDashboard = React.memo(() => {
           <UsageStatistics />
         </TabsContent>
 
-                 <TabsContent value="plans">
-          <div className="space-y-6">
-            <SupabaseTest />
-            <SupabaseClientTest />
-            <ReactQueryTest />
-            <PlansTest />
-            <PlanUpgradeEnhanced />
-          </div>
+        <TabsContent value="plans">
+          <PlanUpgradeEnhanced />
         </TabsContent>
 
         <TabsContent value="payments">

--- a/src/index.css
+++ b/src/index.css
@@ -11,69 +11,69 @@
 
 @layer base {
   :root {
-    /* Improved Color Palette - Gunmetal Navy Theme */
-    --background: 222 84% 5%; /* #0F172A - Gunmetal Navy */
-    --foreground: 210 40% 98%; /* #F1F5F9 - Text Primary */
-    --card: 217 33% 17%; /* #1E293B - Dark Slate */
+    /* Modern Tech Network Theme - Cyberpunk Inspired */
+    --background: 220 23% 6%; /* #0A0D14 - Deep Space Black */
+    --foreground: 210 40% 98%; /* #F1F5F9 - Pure White */
+    --card: 220 23% 9%; /* #111827 - Dark Slate */
     --card-foreground: 210 40% 98%;
-    --popover: 217 33% 17%;
+    --popover: 220 23% 9%;
     --popover-foreground: 210 40% 98%;
-    --primary: 217 91% 60%; /* #3B82F6 - Blue-500 */
+    --primary: 199 89% 48%; /* #0EA5E9 - Electric Blue */
     --primary-foreground: 210 40% 98%;
-    --secondary: 217 33% 17%;
+    --secondary: 220 23% 12%; /* #1F2937 - Dark Gray */
     --secondary-foreground: 210 40% 98%;
-    --muted: 217 33% 17%;
+    --muted: 220 23% 12%;
     --muted-foreground: 148 16% 47%; /* #94A3B8 - Text Secondary */
-    --accent: 217 91% 60%;
+    --accent: 262 83% 58%; /* #8B5CF6 - Electric Purple */
     --accent-foreground: 210 40% 98%;
-    --destructive: 0 84% 60%; /* #EF4444 - Red-500 */
+    --destructive: 0 84% 60%; /* #EF4444 - Neon Red */
     --destructive-foreground: 210 40% 98%;
-    --border: 217 33% 17%;
-    --input: 217 33% 17%;
-    --ring: 217 91% 60%;
+    --border: 220 23% 12%;
+    --input: 220 23% 12%;
+    --ring: 199 89% 48%;
     --radius: 0.75rem;
-    --chart-1: 217 91% 60%; /* Blue-500 */
-    --chart-2: 146 50% 36%; /* Forest Green */
-    --chart-3: 40 71% 67%; /* Sand Gold */
-    --chart-4: 222 84% 5%; /* Gunmetal Navy */
-    --chart-5: 0 84% 60%; /* Red-500 */
+    --chart-1: 199 89% 48%; /* Electric Blue */
+    --chart-2: 262 83% 58%; /* Electric Purple */
+    --chart-3: 34 97% 64%; /* Cyber Orange */
+    --chart-4: 220 23% 6%; /* Deep Space Black */
+    --chart-5: 0 84% 60%; /* Neon Red */
     
-    /* Sidebar theme - Gunmetal Navy base */
-    --sidebar-background: 222 84% 5%; /* Gunmetal Navy */
+    /* Sidebar theme - Cyberpunk base */
+    --sidebar-background: 220 23% 6%; /* Deep Space Black */
     --sidebar-foreground: 210 40% 98%;
-    --sidebar-primary: 217 91% 60%; /* Blue-500 */
+    --sidebar-primary: 199 89% 48%; /* Electric Blue */
     --sidebar-primary-foreground: 210 40% 98%;
-    --sidebar-accent: 146 50% 36%; /* Forest Green */
+    --sidebar-accent: 262 83% 58%; /* Electric Purple */
     --sidebar-accent-foreground: 210 40% 98%;
-    --sidebar-border: 217 33% 17%;
-    --sidebar-ring: 217 91% 60%;
+    --sidebar-border: 220 23% 12%;
+    --sidebar-ring: 199 89% 48%;
   }
 
   .dark {
-    /* Professional dark mode with Gunmetal Navy theme */
-    --background: 222 84% 5%; /* Gunmetal Navy background */
+    /* Professional dark mode with Cyberpunk theme */
+    --background: 220 23% 6%; /* Deep Space Black background */
     --foreground: 210 40% 98%;
-    --card: 217 33% 17%; /* Dark Slate */
+    --card: 220 23% 9%; /* Dark Slate */
     --card-foreground: 210 40% 98%;
-    --popover: 217 33% 17%;
+    --popover: 220 23% 9%;
     --popover-foreground: 210 40% 98%;
-    --primary: 217 91% 60%; /* Blue-500 */
-    --primary-foreground: 222 84% 5%;
-    --secondary: 217 33% 17%;
+    --primary: 199 89% 48%; /* Electric Blue */
+    --primary-foreground: 220 23% 6%;
+    --secondary: 220 23% 12%;
     --secondary-foreground: 210 40% 98%;
-    --muted: 217 33% 17%;
+    --muted: 220 23% 12%;
     --muted-foreground: 148 16% 47%; /* #94A3B8 - Text Secondary */
-    --accent: 146 50% 45%; /* Forest Green accent */
+    --accent: 262 83% 58%; /* Electric Purple accent */
     --accent-foreground: 210 40% 98%;
-    --destructive: 0 84% 60%; /* #EF4444 - Red-500 */
+    --destructive: 0 84% 60%; /* #EF4444 - Neon Red */
     --destructive-foreground: 210 40% 98%;
-    --border: 217 33% 17%;
-    --input: 217 33% 17%;
-    --ring: 217 91% 60%;
-    --chart-1: 217 91% 60%;
-    --chart-2: 146 50% 45%;
-    --chart-3: 40 71% 67%;
-    --chart-4: 217 33% 17%;
+    --border: 220 23% 12%;
+    --input: 220 23% 12%;
+    --ring: 199 89% 48%;
+    --chart-1: 199 89% 48%;
+    --chart-2: 262 83% 58%;
+    --chart-3: 34 97% 64%;
+    --chart-4: 220 23% 12%;
     --chart-5: 0 84% 60%;
   }
 }
@@ -83,11 +83,13 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground font-sans;
+    @apply bg-slate-950 text-foreground font-sans;
     font-feature-settings: "rlig" 1, "calt" 1;
-    /* Tech-inspired subtle pattern */
-    background-image: radial-gradient(circle at 1px 1px, rgba(59, 130, 246, 0.03) 1px, transparent 0);
-    background-size: 40px 40px;
+    /* Tech-inspired subtle pattern with cyberpunk aesthetic */
+    background-image: 
+      radial-gradient(circle at 1px 1px, rgba(14, 165, 233, 0.05) 1px, transparent 0),
+      linear-gradient(45deg, transparent 49%, rgba(139, 92, 246, 0.02) 50%, transparent 51%);
+    background-size: 40px 40px, 80px 80px;
   }
   
   h1, h2, h3, h4, h5, h6 {
@@ -218,23 +220,23 @@
   }
   
   .cyber-card {
-    @apply bg-background/90 backdrop-blur-sm rounded-2xl border border-primary/20 shadow-cyber text-foreground;
+    @apply bg-slate-900/90 backdrop-blur-sm rounded-2xl border border-cyber-blue/20 shadow-cyber text-foreground;
   }
   
   .gradient-primary {
-    @apply bg-gradient-to-r from-blue-600 to-blue-700;
+    @apply bg-gradient-to-r from-cyber-blue-600 to-cyber-blue-700;
   }
   
   .gradient-accent {
-    @apply bg-gradient-to-r from-green-500 to-green-600;
+    @apply bg-gradient-to-r from-cyber-purple-500 to-cyber-purple-600;
   }
   
   .gradient-cyber {
-    @apply bg-gradient-to-br from-slate-800 via-slate-700 to-blue-800;
+    @apply bg-gradient-to-br from-cyber-black-500 via-cyber-gray-700 to-cyber-blue-800;
   }
   
   .gradient-kenyan {
-    @apply bg-gradient-to-r from-yellow-400 to-yellow-600;
+    @apply bg-gradient-to-r from-cyber-orange-400 to-cyber-orange-600;
   }
   
   .status-indicator {
@@ -242,19 +244,19 @@
   }
   
   .status-active {
-    @apply status-indicator bg-green-100 text-green-800;
+    @apply status-indicator bg-cyber-green-100 text-cyber-green-800 dark:bg-cyber-green-900 dark:text-cyber-green-200;
   }
   
   .status-inactive {
-    @apply status-indicator bg-gray-100 text-gray-800;
+    @apply status-indicator bg-cyber-gray-100 text-cyber-gray-800 dark:bg-cyber-gray-900 dark:text-cyber-gray-200;
   }
   
   .status-pending {
-    @apply status-indicator bg-yellow-100 text-yellow-800;
+    @apply status-indicator bg-cyber-orange-100 text-cyber-orange-800 dark:bg-cyber-orange-900 dark:text-cyber-orange-200;
   }
   
   .status-error {
-    @apply status-indicator bg-red-100 text-red-800;
+    @apply status-indicator bg-cyber-red-100 text-cyber-red-800 dark:bg-cyber-red-900 dark:text-cyber-red-200;
   }
   
   .section-divider {
@@ -266,27 +268,31 @@
   }
   
   .cyber-border {
-    @apply border border-primary/30 shadow-cyber;
+    @apply border border-cyber-blue/30 shadow-cyber;
   }
   
-  .kenyan-accent {
-    @apply border-l-4 border-yellow-500 bg-yellow-50/50;
+  .cyber-accent {
+    @apply border-l-4 border-cyber-purple-500 bg-cyber-purple-50/50 dark:bg-cyber-purple-900/20;
   }
   
   .btn-primary {
-    @apply bg-primary hover:bg-blue-600 text-primary-foreground rounded-lg transition-all duration-200 ease-in-out shadow-md hover:shadow-lg;
+    @apply bg-cyber-blue-600 hover:bg-cyber-blue-700 text-white rounded-lg transition-all duration-200 ease-in-out shadow-md hover:shadow-lg;
   }
   
   .btn-secondary {
-    @apply bg-secondary hover:bg-secondary/80 text-secondary-foreground rounded-lg transition-all duration-200 ease-in-out;
+    @apply bg-cyber-gray-600 hover:bg-cyber-gray-700 text-white rounded-lg transition-all duration-200 ease-in-out;
+  }
+  
+  .btn-accent {
+    @apply bg-cyber-purple-600 hover:bg-cyber-purple-700 text-white rounded-lg transition-all duration-200 ease-in-out shadow-md hover:shadow-lg;
   }
   
   .navbar-cyber {
-    @apply bg-background text-foreground shadow-cyber;
+    @apply bg-slate-950 text-foreground shadow-cyber;
   }
   
   .footer-cyber {
-    @apply bg-background text-foreground border-t border-border;
+    @apply bg-slate-950 text-foreground border-t border-border;
   }
   
   /* Mobile-specific improvements */
@@ -295,7 +301,7 @@
   }
   
   .mobile-nav {
-    @apply sm:hidden fixed bottom-0 left-0 right-0 z-50 bg-cyber-navy-500 border-t border-ocean-blue-400/20;
+    @apply sm:hidden fixed bottom-0 left-0 right-0 z-50 bg-cyber-black-500 border-t border-cyber-blue-400/20;
   }
   
   /* Animation delays for staggered effects */
@@ -309,6 +315,23 @@
   
   .animation-delay-1000 {
     animation-delay: 1000ms;
+  }
+  
+  /* Cyberpunk theme specific utilities */
+  .cyber-text-glow {
+    @apply text-cyber-blue-400 drop-shadow-[0_0_8px_rgba(14,165,233,0.3)];
+  }
+  
+  .cyber-border-glow {
+    @apply border border-cyber-blue/50 shadow-[0_0_20px_rgba(14,165,233,0.2)];
+  }
+  
+  .cyber-bg-gradient {
+    @apply bg-gradient-to-br from-cyber-black-500 via-cyber-gray-700 to-cyber-blue-900;
+  }
+  
+  .cyber-card-hover {
+    @apply hover:shadow-cyber-glow hover:border-cyber-purple/50 transition-all duration-300;
   }
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -19,90 +19,90 @@ export default {
 		},
 		extend: {
 			colors: {
-				// Modern Tech + Kenyan Accent + Cybersecurity Theme Colors
-				'ocean-blue': {
-					50: '#e6f4ff',
-					100: '#bae0ff',
-					200: '#91ccff',
-					300: '#69b8ff',
-					400: '#40a4ff',
-					500: '#0077B6', // Primary Ocean Blue
-					600: '#006ba3',
-					700: '#005c8f',
-					800: '#004d7a',
-					900: '#003d66',
+				// Modern Cyberpunk Tech Theme Colors
+				'cyber-blue': {
+					50: '#e0f7ff',
+					100: '#b3ecff',
+					200: '#80e0ff',
+					300: '#4dd4ff',
+					400: '#1ac8ff',
+					500: '#0EA5E9', // Primary Electric Blue
+					600: '#0c94d6',
+					700: '#0a83c3',
+					800: '#0872b0',
+					900: '#06619d',
 				},
-				'forest-green': {
-					50: '#e8f5e8',
-					100: '#c3e6c3',
-					200: '#9dd69d',
-					300: '#78c678',
-					400: '#52b652',
-					500: '#2E8B57', // Accent Forest Green
-					600: '#297d4e',
-					700: '#246f44',
-					800: '#1f613b',
-					900: '#1a5331',
+				'cyber-purple': {
+					50: '#f3e8ff',
+					100: '#e9d5ff',
+					200: '#d8b4ff',
+					300: '#c084fc',
+					400: '#a855f7',
+					500: '#8B5CF6', // Electric Purple
+					600: '#7c3aed',
+					700: '#6d28d9',
+					800: '#5b21b6',
+					900: '#4c1d95',
 				},
-				'cyber-navy': {
-					50: '#e6ecf5',
-					100: '#bfd1e6',
-					200: '#99b6d6',
-					300: '#729bc7',
-					400: '#4c80b7',
-					500: '#0A192F', // Dark Base Cyber Navy
-					600: '#09172a',
-					700: '#081425',
-					800: '#061220',
-					900: '#050f1a',
+				'cyber-orange': {
+					50: '#fff7ed',
+					100: '#ffedd5',
+					200: '#fed7aa',
+					300: '#fdba74',
+					400: '#fb923c',
+					500: '#F97316', // Cyber Orange
+					600: '#ea580c',
+					700: '#c2410c',
+					800: '#9a3412',
+					900: '#7c2d12',
 				},
-				'sand-gold': {
-					50: '#fefaf5',
-					100: '#fcf2e6',
-					200: '#f9e9d6',
-					300: '#f7e1c7',
-					400: '#f5d8b7',
-					500: '#F4A460', // Card Accent Sand Gold
-					600: '#f19440',
-					700: '#ee8320',
-					800: '#eb7300',
-					900: '#d66700',
+				'cyber-black': {
+					50: '#f8fafc',
+					100: '#f1f5f9',
+					200: '#e2e8f0',
+					300: '#cbd5e1',
+					400: '#94a3b8',
+					500: '#0A0D14', // Deep Space Black
+					600: '#1F2937',
+					700: '#374151',
+					800: '#4B5563',
+					900: '#6B7280',
 				},
-				'charcoal-grey': {
-					50: '#f5f5f5',
-					100: '#e8e8e8',
-					200: '#dadada',
-					300: '#cdcdcd',
-					400: '#bfbfbf',
-					500: '#1F1F1F', // Text Charcoal Grey
-					600: '#1c1c1c',
-					700: '#191919',
-					800: '#161616',
-					900: '#131313',
+				'cyber-gray': {
+					50: '#f9fafb',
+					100: '#f3f4f6',
+					200: '#e5e7eb',
+					300: '#d1d5db',
+					400: '#9ca3af',
+					500: '#6B7280', // Cyber Gray
+					600: '#4B5563',
+					700: '#374151',
+					800: '#1F2937',
+					900: '#111827',
 				},
-				'light-grey': {
-					50: '#fdfdfd',
-					100: '#fcfcfc',
-					200: '#fafafa',
-					300: '#f9f9f9',
-					400: '#f8f8f8',
-					500: '#F8F9FA', // Background Light Grey
-					600: '#e0e1e3',
-					700: '#c7c9cc',
-					800: '#afb0b4',
-					900: '#96989d',
+				'cyber-green': {
+					50: '#ecfdf5',
+					100: '#d1fae5',
+					200: '#a7f3d0',
+					300: '#6ee7b7',
+					400: '#34d399',
+					500: '#10B981', // Cyber Green
+					600: '#059669',
+					700: '#047857',
+					800: '#065f46',
+					900: '#064e3b',
 				},
-				'alert-red': {
-					50: '#fff5f5',
-					100: '#ffe0e0',
-					200: '#ffcccc',
-					300: '#ffb3b3',
-					400: '#ff9999',
-					500: '#FF4C4C', // Alert/Errors Red
-					600: '#e63333',
-					700: '#cc1a1a',
-					800: '#b30000',
-					900: '#990000',
+				'cyber-red': {
+					50: '#fef2f2',
+					100: '#fee2e2',
+					200: '#fecaca',
+					300: '#fca5a5',
+					400: '#f87171',
+					500: '#EF4444', // Neon Red
+					600: '#dc2626',
+					700: '#b91c1c',
+					800: '#991b1b',
+					900: '#7f1d1d',
 				},
 				
 				// Professional ISP theme colors (preserved for compatibility)
@@ -212,8 +212,9 @@ export default {
 				'strong': '0 10px 40px -10px rgba(0, 0, 0, 0.15), 0 2px 8px -2px rgba(0, 0, 0, 0.1)',
 				'card': '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
 				'card-hover': '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
-				'cyber': '0 4px 20px rgba(10, 25, 47, 0.3), 0 2px 10px rgba(0, 119, 182, 0.1)',
-				'glow': '0 0 20px rgba(0, 119, 182, 0.3), 0 0 40px rgba(0, 119, 182, 0.1)',
+				'cyber': '0 4px 20px rgba(10, 13, 20, 0.3), 0 2px 10px rgba(14, 165, 233, 0.1)',
+				'glow': '0 0 20px rgba(14, 165, 233, 0.3), 0 0 40px rgba(14, 165, 233, 0.1)',
+				'cyber-glow': '0 0 30px rgba(139, 92, 246, 0.4), 0 0 60px rgba(139, 92, 246, 0.2)',
 			},
 			borderRadius: {
 				lg: 'var(--radius)',
@@ -256,8 +257,12 @@ export default {
 					'100%': { opacity: '1', transform: 'translateY(0) scale(1)' }
 				},
 				'glow-pulse': {
-					'0%, 100%': { boxShadow: '0 0 20px rgba(0, 119, 182, 0.3)' },
-					'50%': { boxShadow: '0 0 30px rgba(0, 119, 182, 0.6), 0 0 40px rgba(0, 119, 182, 0.3)' }
+					'0%, 100%': { boxShadow: '0 0 20px rgba(14, 165, 233, 0.3)' },
+					'50%': { boxShadow: '0 0 30px rgba(14, 165, 233, 0.6), 0 0 40px rgba(14, 165, 233, 0.3)' }
+				},
+				'cyber-pulse': {
+					'0%, 100%': { boxShadow: '0 0 20px rgba(139, 92, 246, 0.3)' },
+					'50%': { boxShadow: '0 0 30px rgba(139, 92, 246, 0.6), 0 0 40px rgba(139, 92, 246, 0.3)' }
 				}
 			},
 			animation: {
@@ -267,7 +272,8 @@ export default {
 				'slide-up': 'slide-up 0.3s ease-out',
 				'scale-in': 'scale-in 0.2s ease-out',
 				'dropdown-open': 'dropdown-open 0.15s ease-out',
-				'glow-pulse': 'glow-pulse 2s ease-in-out infinite'
+				'glow-pulse': 'glow-pulse 2s ease-in-out infinite',
+				'cyber-pulse': 'cyber-pulse 2s ease-in-out infinite'
 			}
 		}
 	},


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Integrate direct STK push payment into the plans tab and apply a new cyberpunk-inspired UI theme.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The plans tab now defaults to open, and selecting a plan directly initiates the STK push payment, streamlining the user workflow to match the existing payment tab. This update also introduces a modern, high-tech aesthetic through a new cyberpunk-inspired color palette and styling, addressing previous UI inconsistencies.

---
<a href="https://cursor.com/background-agent?bcId=bc-840ce4ea-5d95-4bc3-b460-88a7fbbcd91f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-840ce4ea-5d95-4bc3-b460-88a7fbbcd91f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>